### PR TITLE
Fix the fixed-point; keep the hostname

### DIFF
--- a/roses/cromwell-nix.nix
+++ b/roses/cromwell-nix.nix
@@ -17,5 +17,7 @@
     experimental-features = nix-command flakes
   '';
 
+  networking.hostName = "cromwell-nix";
+
   system.stateVersion = "22.05";
 }


### PR DESCRIPTION
I accidentally removed the hostname configuration, so Nix started getting confused as to what configuration to apply.

Include `hostName` in the `cromwell-nix.nix` file, so that the hostname (and therefore configuration) stays the same across re-evaluations.